### PR TITLE
Added lines method, draws lines between points given

### DIFF
--- a/src/orbital/window.rs
+++ b/src/orbital/window.rs
@@ -162,6 +162,18 @@ impl Window {
         }
     }
 
+    pub fn lines(&mut self, points: &[[i32; 2]], color: Color) {
+        if points.len() == 0 {
+            // when no points given, do nothing
+        } else if points.len() == 1 {
+            self.pixel(points[0][0], points[0][1], color);
+        } else {
+            for i in 0..points.len() - 1 {
+                self.line(points[i][0], points[i][1], points[i+1][0], points[i+1][1], color);
+            }
+        }
+    }
+
     /// Draw a character, using the loaded font
     pub fn char(&mut self, x: i32, y: i32, c: char, color: Color) {
         let mut offset = (c as usize) * 16;

--- a/src/sdl2/window.rs
+++ b/src/sdl2/window.rs
@@ -130,6 +130,19 @@ impl Window {
         self.inner.set_draw_color(sdl2::pixels::Color::RGBA((color.data >> 16) as u8, (color.data >> 8) as u8, color.data as u8, (color.data >> 24) as u8));
         self.inner.draw_line(sdl2::rect::Point::new(x1, y1), sdl2::rect::Point::new(x2, y2));
     }
+
+    /// Draw multiple lines from point to point.
+    pub fn lines(&mut self, points: &[[i32; 2]], color: Color) {
+        if points.len() == 0 {
+            // when no points given, do nothing
+        } else if points.len() == 1 {
+            self.pixel(points[0][0], points[0][1], color);
+        } else {
+            for i in 0..points.len() - 1 {
+                self.line(points[i][0], points[i][1], points[i+1][0], points[i+1][1], color);
+            }
+        }
+    }
     
     /// Draw a character, using the loaded font
     pub fn char(&mut self, x: i32, y: i32, c: char, color: Color) {


### PR DESCRIPTION
I added a method to add lines between given points.

It accepts a reference to an array of `[i32; 2]`. It draws line following each point one by one.

`[[10, 10], [20, 20]]` draws one line from `10, 10` to `20, 20`  
`[[10, 10], [20, 20], [30, 10]]` draws two lines, from `10, 10` to `20, 20`, and from `20, 20` to `30, 10`  
etc. 

Test code

```
extern crate orbclient;

use orbclient::window::Window;
use orbclient::color::Color;

fn main() {
    let mut window = Window::new(20, 20, 640, 480, &"Hello!").unwrap();
    let mut counter = 0.0; 
    loop {
        window.set(Color::rgb(0,0,0));
        window.lines(&[[0, 10 + counter as i32],
                       [50, 200 + (counter*0.5) as i32],
                       [200, 200 - counter as i32],
                       [300, 100 + counter as i32]], Color::rgb(255, 0, 0));
        window.sync();
        counter += 0.05;
    }
}
```