### PR TITLE
Remove the deprecated attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(associated_consts)]
 #![feature(const_fn)]
 #![feature(box_syntax)]
-#![feature(deprecated)]
 
 #![deny(warnings)]
 


### PR DESCRIPTION
The `deprecated` feature is stable on the latest nightly.