### PR TITLE
Make login window unclosable/kill resize event (orbital.rs, lib.rs)

### DIFF
--- a/src/imp/orbital.rs
+++ b/src/imp/orbital.rs
@@ -85,17 +85,20 @@ impl Window {
     pub fn new_flags(x: i32, y: i32, w: u32, h: u32, title: &str, flags: &[WindowFlag]) -> Option<Self> {
         let mut async = false;
         let mut resizable = false;
+        let mut exit = true;
         for &flag in flags.iter() {
             match flag {
                 WindowFlag::Async => async = true,
                 WindowFlag::Resizable => resizable = true,
+                WindowFlag::Exit => exit = false
             }
         }
 
         if let Ok(file) = File::open(&format!(
-            "orbital:{}{}/{}/{}/{}/{}/{}",
+            "orbital:{}{}{}/{}/{}/{}/{}/{}",
             if async { "a" } else { "" },
             if resizable { "r" } else { "" },
+            if exit == false { "e" } else { "" },
             x, y, w, h, title
         )) {
             if let Ok(address) = unsafe { syscall::fmap(file.as_raw_fd(), 0, (w * h * 4) as usize) } {

--- a/src/imp/orbital.rs
+++ b/src/imp/orbital.rs
@@ -85,12 +85,12 @@ impl Window {
     pub fn new_flags(x: i32, y: i32, w: u32, h: u32, title: &str, flags: &[WindowFlag]) -> Option<Self> {
         let mut async = false;
         let mut resizable = false;
-        let mut exit = true;
+        let mut unclosable = false;
         for &flag in flags.iter() {
             match flag {
                 WindowFlag::Async => async = true,
                 WindowFlag::Resizable => resizable = true,
-                WindowFlag::Exit => exit = false
+                WindowFlag::Unclosable => unclosable = true
             }
         }
 
@@ -98,7 +98,7 @@ impl Window {
             "orbital:{}{}{}/{}/{}/{}/{}/{}",
             if async { "a" } else { "" },
             if resizable { "r" } else { "" },
-            if exit == false { "e" } else { "" },
+            if unclosable { "u" } else { "" },
             x, y, w, h, title
         )) {
             if let Ok(address) = unsafe { syscall::fmap(file.as_raw_fd(), 0, (w * h * 4) as usize) } {

--- a/src/imp/sdl2.rs
+++ b/src/imp/sdl2.rs
@@ -99,10 +99,12 @@ impl Window {
 
         let mut async = false;
         let mut resizable = false;
+        let mut exit = true;
         for &flag in flags.iter() {
             match flag {
                 WindowFlag::Async => async = true,
                 WindowFlag::Resizable => resizable = true,
+                WindowFlag::Exit => exit = false,
             }
         }
 

--- a/src/imp/sdl2.rs
+++ b/src/imp/sdl2.rs
@@ -99,12 +99,12 @@ impl Window {
 
         let mut async = false;
         let mut resizable = false;
-        let mut exit = true;
+        let mut unclosable = false;
         for &flag in flags.iter() {
             match flag {
                 WindowFlag::Async => async = true,
                 WindowFlag::Resizable => resizable = true,
-                WindowFlag::Exit => exit = false,
+                WindowFlag::Unclosable => unclosable = true,
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,8 @@ pub mod renderer;
 #[derive(Clone, Copy, Debug)]
 pub enum WindowFlag {
     Async,
-    Resizable
+    Resizable,
+    Exit
 }
 
 #[cfg(target_os = "redox")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod renderer;
 pub enum WindowFlag {
     Async,
     Resizable,
-    Exit
+    Unclosable
 }
 
 #[cfg(target_os = "redox")]


### PR DESCRIPTION
Orbital: Added an exit flag to orbital.rs, along with adding an "e" if a window
passes the flag to the file. in Window::new_flags (set to true for
default)

sdl2: added exit flag (set to true as default)

Other pull requests which fix this issue but in different git submodules are under the same branch name (make-orbital-login-unclosable)

this also fixes the issue with the Resizable event firing even when the window is not supposed to be resizable.

PRS:
https://github.com/redox-os/orbclient/pull/29
https://github.com/redox-os/orbital/pull/13
https://github.com/redox-os/orbtk/pull/42
https://github.com/redox-os/orbutils/pulls

Original Issues:
https://github.com/redox-os/orbital/issues/11
https://github.com/redox-os/redox/issues/859