### PR TITLE
Separate keycodes and scancodes. Update KeyEvent.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ sdl2 = "0.29"
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.1"
+
+[dependencies]
+bitflags = "0.8.2"
+redox_syscall = "0.1.17"

--- a/src/imp/orbital.rs
+++ b/src/imp/orbital.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use color::Color;
-use event::{Event, EVENT_RESIZE};
+use input::{Event, EVENT_RESIZE};
 use renderer::Renderer;
 use WindowFlag;
 

--- a/src/imp/sdl2.rs
+++ b/src/imp/sdl2.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 
 use color::Color;
 use event::*;
+use input::scancode::*;
 use renderer::Renderer;
 use WindowFlag;
 
@@ -195,85 +196,85 @@ impl Window {
     fn convert_scancode(&self, scancode_option: Option<sdl2::keyboard::Scancode>, shift: bool) -> Option<(char, u8)> {
         if let Some(scancode) = scancode_option {
             match scancode {
-                sdl2::keyboard::Scancode::A => Some((if shift { 'A' } else { 'a' }, K_A)),
-                sdl2::keyboard::Scancode::B => Some((if shift { 'B' } else { 'b' }, K_B)),
-                sdl2::keyboard::Scancode::C => Some((if shift { 'C' } else { 'c' }, K_C)),
-                sdl2::keyboard::Scancode::D => Some((if shift { 'D' } else { 'd' }, K_D)),
-                sdl2::keyboard::Scancode::E => Some((if shift { 'E' } else { 'e' }, K_E)),
-                sdl2::keyboard::Scancode::F => Some((if shift { 'F' } else { 'f' }, K_F)),
-                sdl2::keyboard::Scancode::G => Some((if shift { 'G' } else { 'g' }, K_G)),
-                sdl2::keyboard::Scancode::H => Some((if shift { 'H' } else { 'h' }, K_H)),
-                sdl2::keyboard::Scancode::I => Some((if shift { 'I' } else { 'i' }, K_I)),
-                sdl2::keyboard::Scancode::J => Some((if shift { 'J' } else { 'j' }, K_J)),
-                sdl2::keyboard::Scancode::K => Some((if shift { 'K' } else { 'k' }, K_K)),
-                sdl2::keyboard::Scancode::L => Some((if shift { 'L' } else { 'l' }, K_L)),
-                sdl2::keyboard::Scancode::M => Some((if shift { 'M' } else { 'm' }, K_M)),
-                sdl2::keyboard::Scancode::N => Some((if shift { 'N' } else { 'n' }, K_N)),
-                sdl2::keyboard::Scancode::O => Some((if shift { 'O' } else { 'o' }, K_O)),
-                sdl2::keyboard::Scancode::P => Some((if shift { 'P' } else { 'p' }, K_P)),
-                sdl2::keyboard::Scancode::Q => Some((if shift { 'Q' } else { 'q' }, K_Q)),
-                sdl2::keyboard::Scancode::R => Some((if shift { 'R' } else { 'r' }, K_R)),
-                sdl2::keyboard::Scancode::S => Some((if shift { 'S' } else { 's' }, K_S)),
-                sdl2::keyboard::Scancode::T => Some((if shift { 'T' } else { 't' }, K_T)),
-                sdl2::keyboard::Scancode::U => Some((if shift { 'U' } else { 'u' }, K_U)),
-                sdl2::keyboard::Scancode::V => Some((if shift { 'V' } else { 'v' }, K_V)),
-                sdl2::keyboard::Scancode::W => Some((if shift { 'W' } else { 'w' }, K_W)),
-                sdl2::keyboard::Scancode::X => Some((if shift { 'X' } else { 'x' }, K_X)),
-                sdl2::keyboard::Scancode::Y => Some((if shift { 'Y' } else { 'y' }, K_Y)),
-                sdl2::keyboard::Scancode::Z => Some((if shift { 'Z' } else { 'z' }, K_Z)),
-                sdl2::keyboard::Scancode::Num0 => Some((if shift { ')' } else { '0' }, K_0)),
-                sdl2::keyboard::Scancode::Num1 => Some((if shift { '!' } else { '1' }, K_1)),
-                sdl2::keyboard::Scancode::Num2 => Some((if shift { '@' } else { '2' }, K_2)),
-                sdl2::keyboard::Scancode::Num3 => Some((if shift { '#' } else { '3' }, K_3)),
-                sdl2::keyboard::Scancode::Num4 => Some((if shift { '$' } else { '4' }, K_4)),
-                sdl2::keyboard::Scancode::Num5 => Some((if shift { '%' } else { '5' }, K_5)),
-                sdl2::keyboard::Scancode::Num6 => Some((if shift { '^' } else { '6' }, K_6)),
-                sdl2::keyboard::Scancode::Num7 => Some((if shift { '&' } else { '7' }, K_7)),
-                sdl2::keyboard::Scancode::Num8 => Some((if shift { '*' } else { '8' }, K_8)),
-                sdl2::keyboard::Scancode::Num9 => Some((if shift { '(' } else { '9' }, K_9)),
-                sdl2::keyboard::Scancode::Grave => Some((if shift { '~' } else { '`' }, K_TICK)),
-                sdl2::keyboard::Scancode::Minus => Some((if shift { '_' } else { '-' }, K_MINUS)),
-                sdl2::keyboard::Scancode::Equals => Some((if shift { '+' } else { '=' }, K_EQUALS)),
-                sdl2::keyboard::Scancode::LeftBracket => Some((if shift { '{' } else { '[' }, K_BRACE_OPEN)),
-                sdl2::keyboard::Scancode::RightBracket => Some((if shift { '}' } else { ']' }, K_BRACE_CLOSE)),
-                sdl2::keyboard::Scancode::Backslash => Some((if shift { '|' } else { '\\' }, K_BACKSLASH)),
-                sdl2::keyboard::Scancode::Semicolon => Some((if shift { ':' } else { ';' }, K_SEMICOLON)),
-                sdl2::keyboard::Scancode::Apostrophe => Some((if shift { '"' } else { '\'' }, K_QUOTE)),
-                sdl2::keyboard::Scancode::Comma => Some((if shift { '<' } else { ',' }, K_COMMA)),
-                sdl2::keyboard::Scancode::Period => Some((if shift { '>' } else { '.' }, K_PERIOD)),
-                sdl2::keyboard::Scancode::Slash => Some((if shift { '?' } else { '/' }, K_SLASH)),
-                sdl2::keyboard::Scancode::Space => Some((' ', K_SPACE)),
-                sdl2::keyboard::Scancode::Backspace => Some(('\0', K_BKSP)),
-                sdl2::keyboard::Scancode::Tab => Some(('\t', K_TAB)),
-                sdl2::keyboard::Scancode::LCtrl => Some(('\0', K_CTRL)),
-                sdl2::keyboard::Scancode::RCtrl => Some(('\0', K_CTRL)),
-                sdl2::keyboard::Scancode::LAlt => Some(('\0', K_ALT)),
-                sdl2::keyboard::Scancode::RAlt => Some(('\0', K_ALT)),
-                sdl2::keyboard::Scancode::Return => Some(('\n', K_ENTER)),
-                sdl2::keyboard::Scancode::Escape => Some(('\x1B', K_ESC)),
-                sdl2::keyboard::Scancode::F1 => Some(('\0', K_F1)),
-                sdl2::keyboard::Scancode::F2 => Some(('\0', K_F2)),
-                sdl2::keyboard::Scancode::F3 => Some(('\0', K_F3)),
-                sdl2::keyboard::Scancode::F4 => Some(('\0', K_F4)),
-                sdl2::keyboard::Scancode::F5 => Some(('\0', K_F5)),
-                sdl2::keyboard::Scancode::F6 => Some(('\0', K_F6)),
-                sdl2::keyboard::Scancode::F7 => Some(('\0', K_F7)),
-                sdl2::keyboard::Scancode::F8 => Some(('\0', K_F8)),
-                sdl2::keyboard::Scancode::F9 => Some(('\0', K_F9)),
-                sdl2::keyboard::Scancode::F10 => Some(('\0', K_F10)),
-                sdl2::keyboard::Scancode::Home => Some(('\0', K_HOME)),
-                sdl2::keyboard::Scancode::Up => Some(('\0', K_UP)),
-                sdl2::keyboard::Scancode::PageUp => Some(('\0', K_PGUP)),
-                sdl2::keyboard::Scancode::Left => Some(('\0', K_LEFT)),
-                sdl2::keyboard::Scancode::Right => Some(('\0', K_RIGHT)),
-                sdl2::keyboard::Scancode::End => Some(('\0', K_END)),
-                sdl2::keyboard::Scancode::Down => Some(('\0', K_DOWN)),
-                sdl2::keyboard::Scancode::PageDown => Some(('\0', K_PGDN)),
-                sdl2::keyboard::Scancode::Delete => Some(('\0', K_DEL)),
-                sdl2::keyboard::Scancode::F11 => Some(('\0', K_F11)),
-                sdl2::keyboard::Scancode::F12 => Some(('\0', K_F12)),
-                sdl2::keyboard::Scancode::LShift => Some(('\0', K_LEFT_SHIFT)),
-                sdl2::keyboard::Scancode::RShift => Some(('\0', K_RIGHT_SHIFT)),
+                sdl2::keyboard::Scancode::A => Some((if shift { 'A' } else { 'a' }, SC_A)),
+                sdl2::keyboard::Scancode::B => Some((if shift { 'B' } else { 'b' }, SC_B)),
+                sdl2::keyboard::Scancode::C => Some((if shift { 'C' } else { 'c' }, SC_C)),
+                sdl2::keyboard::Scancode::D => Some((if shift { 'D' } else { 'd' }, SC_D)),
+                sdl2::keyboard::Scancode::E => Some((if shift { 'E' } else { 'e' }, SC_E)),
+                sdl2::keyboard::Scancode::F => Some((if shift { 'F' } else { 'f' }, SC_F)),
+                sdl2::keyboard::Scancode::G => Some((if shift { 'G' } else { 'g' }, SC_G)),
+                sdl2::keyboard::Scancode::H => Some((if shift { 'H' } else { 'h' }, SC_H)),
+                sdl2::keyboard::Scancode::I => Some((if shift { 'I' } else { 'i' }, SC_I)),
+                sdl2::keyboard::Scancode::J => Some((if shift { 'J' } else { 'j' }, SC_J)),
+                sdl2::keyboard::Scancode::K => Some((if shift { 'K' } else { 'k' }, SC_K)),
+                sdl2::keyboard::Scancode::L => Some((if shift { 'L' } else { 'l' }, SC_L)),
+                sdl2::keyboard::Scancode::M => Some((if shift { 'M' } else { 'm' }, SC_M)),
+                sdl2::keyboard::Scancode::N => Some((if shift { 'N' } else { 'n' }, SC_N)),
+                sdl2::keyboard::Scancode::O => Some((if shift { 'O' } else { 'o' }, SC_O)),
+                sdl2::keyboard::Scancode::P => Some((if shift { 'P' } else { 'p' }, SC_P)),
+                sdl2::keyboard::Scancode::Q => Some((if shift { 'Q' } else { 'q' }, SC_Q)),
+                sdl2::keyboard::Scancode::R => Some((if shift { 'R' } else { 'r' }, SC_R)),
+                sdl2::keyboard::Scancode::S => Some((if shift { 'S' } else { 's' }, SC_S)),
+                sdl2::keyboard::Scancode::T => Some((if shift { 'T' } else { 't' }, SC_T)),
+                sdl2::keyboard::Scancode::U => Some((if shift { 'U' } else { 'u' }, SC_U)),
+                sdl2::keyboard::Scancode::V => Some((if shift { 'V' } else { 'v' }, SC_V)),
+                sdl2::keyboard::Scancode::W => Some((if shift { 'W' } else { 'w' }, SC_W)),
+                sdl2::keyboard::Scancode::X => Some((if shift { 'X' } else { 'x' }, SC_X)),
+                sdl2::keyboard::Scancode::Y => Some((if shift { 'Y' } else { 'y' }, SC_Y)),
+                sdl2::keyboard::Scancode::Z => Some((if shift { 'Z' } else { 'z' }, SC_Z)),
+                sdl2::keyboard::Scancode::Num0 => Some((if shift { ')' } else { '0' }, SC_0)),
+                sdl2::keyboard::Scancode::Num1 => Some((if shift { '!' } else { '1' }, SC_1)),
+                sdl2::keyboard::Scancode::Num2 => Some((if shift { '@' } else { '2' }, SC_2)),
+                sdl2::keyboard::Scancode::Num3 => Some((if shift { '#' } else { '3' }, SC_3)),
+                sdl2::keyboard::Scancode::Num4 => Some((if shift { '$' } else { '4' }, SC_4)),
+                sdl2::keyboard::Scancode::Num5 => Some((if shift { '%' } else { '5' }, SC_5)),
+                sdl2::keyboard::Scancode::Num6 => Some((if shift { '^' } else { '6' }, SC_6)),
+                sdl2::keyboard::Scancode::Num7 => Some((if shift { '&' } else { '7' }, SC_7)),
+                sdl2::keyboard::Scancode::Num8 => Some((if shift { '*' } else { '8' }, SC_8)),
+                sdl2::keyboard::Scancode::Num9 => Some((if shift { '(' } else { '9' }, SC_9)),
+                sdl2::keyboard::Scancode::Grave => Some((if shift { '~' } else { '`' }, SC_TICK)),
+                sdl2::keyboard::Scancode::Minus => Some((if shift { '_' } else { '-' }, SC_MINUS)),
+                sdl2::keyboard::Scancode::Equals => Some((if shift { '+' } else { '=' }, SC_EQUALS)),
+                sdl2::keyboard::Scancode::LeftBracket => Some((if shift { '{' } else { '[' }, SC_BRACE_OPEN)),
+                sdl2::keyboard::Scancode::RightBracket => Some((if shift { '}' } else { ']' }, SC_BRACE_CLOSE)),
+                sdl2::keyboard::Scancode::Backslash => Some((if shift { '|' } else { '\\' }, SC_BACKSLASH)),
+                sdl2::keyboard::Scancode::Semicolon => Some((if shift { ':' } else { ';' }, SC_SEMICOLON)),
+                sdl2::keyboard::Scancode::Apostrophe => Some((if shift { '"' } else { '\'' }, SC_QUOTE)),
+                sdl2::keyboard::Scancode::Comma => Some((if shift { '<' } else { ',' }, SC_COMMA)),
+                sdl2::keyboard::Scancode::Period => Some((if shift { '>' } else { '.' }, SC_PERIOD)),
+                sdl2::keyboard::Scancode::Slash => Some((if shift { '?' } else { '/' }, SC_SLASH)),
+                sdl2::keyboard::Scancode::Space => Some((' ', SC_SPACE)),
+                sdl2::keyboard::Scancode::Backspace => Some(('\0', SC_BKSP)),
+                sdl2::keyboard::Scancode::Tab => Some(('\t', SC_TAB)),
+                sdl2::keyboard::Scancode::LCtrl => Some(('\0', SC_CTRL)),
+                sdl2::keyboard::Scancode::RCtrl => Some(('\0', SC_CTRL)),
+                sdl2::keyboard::Scancode::LAlt => Some(('\0', SC_ALT)),
+                sdl2::keyboard::Scancode::RAlt => Some(('\0', SC_ALT)),
+                sdl2::keyboard::Scancode::Return => Some(('\n', SC_ENTER)),
+                sdl2::keyboard::Scancode::Escape => Some(('\x1B', SC_ESC)),
+                sdl2::keyboard::Scancode::F1 => Some(('\0', SC_F1)),
+                sdl2::keyboard::Scancode::F2 => Some(('\0', SC_F2)),
+                sdl2::keyboard::Scancode::F3 => Some(('\0', SC_F3)),
+                sdl2::keyboard::Scancode::F4 => Some(('\0', SC_F4)),
+                sdl2::keyboard::Scancode::F5 => Some(('\0', SC_F5)),
+                sdl2::keyboard::Scancode::F6 => Some(('\0', SC_F6)),
+                sdl2::keyboard::Scancode::F7 => Some(('\0', SC_F7)),
+                sdl2::keyboard::Scancode::F8 => Some(('\0', SC_F8)),
+                sdl2::keyboard::Scancode::F9 => Some(('\0', SC_F9)),
+                sdl2::keyboard::Scancode::F10 => Some(('\0', SC_F10)),
+                sdl2::keyboard::Scancode::Home => Some(('\0', SC_HOME)),
+                sdl2::keyboard::Scancode::Up => Some(('\0', SC_UP)),
+                sdl2::keyboard::Scancode::PageUp => Some(('\0', SC_PGUP)),
+                sdl2::keyboard::Scancode::Left => Some(('\0', SC_LEFT)),
+                sdl2::keyboard::Scancode::Right => Some(('\0', SC_RIGHT)),
+                sdl2::keyboard::Scancode::End => Some(('\0', SC_END)),
+                sdl2::keyboard::Scancode::Down => Some(('\0', SC_DOWN)),
+                sdl2::keyboard::Scancode::PageDown => Some(('\0', SC_PGDN)),
+                sdl2::keyboard::Scancode::Delete => Some(('\0', SC_DEL)),
+                sdl2::keyboard::Scancode::F11 => Some(('\0', SC_F11)),
+                sdl2::keyboard::Scancode::F12 => Some(('\0', SC_F12)),
+                sdl2::keyboard::Scancode::LShift => Some(('\0', SC_LEFT_SHIFT)),
+                sdl2::keyboard::Scancode::RShift => Some(('\0', SC_RIGHT_SHIFT)),
                 _ => None
             }
         } else {
@@ -306,45 +307,49 @@ impl Window {
         match event {
             sdl2::event::Event::Window { win_event, .. } => match win_event {
                 sdl2::event::WindowEvent::Moved(x, y) => events.push(MoveEvent {
-                    x: x,
-                    y: y
-                }.to_event()),
+                        x: x,
+                        y: y
+                    }.to_event()),
                 sdl2::event::WindowEvent::Resized(w, h) => events.push(ResizeEvent {
-                    width: w as u32,
-                    height: h as u32
-                }.to_event()),
+                        width: w as u32,
+                        height: h as u32
+                    }.to_event()),
                 sdl2::event::WindowEvent::FocusGained => events.push(FocusEvent {
-                    focused: true
-                }.to_event()),
+                        focused: true
+                    }.to_event()),
                 sdl2::event::WindowEvent::FocusLost => events.push(FocusEvent {
-                    focused: false
-                }.to_event()),
+                        focused: false
+                    }.to_event()),
                 _ => ()
             },
             sdl2::event::Event::MouseMotion { x, y, .. } => events.push(MouseEvent {
-                x: x,
-                y: y
-            }.to_event()),
+                    x: x,
+                    y: y
+                }.to_event()),
             sdl2::event::Event::MouseButtonDown { .. } => events.push(button_event()),
             sdl2::event::Event::MouseButtonUp { .. } => events.push(button_event()),
             sdl2::event::Event::MouseWheel { x, y, .. } => events.push(ScrollEvent {
-                x: x,
-                y: y
-            }.to_event()),
+                    x: x,
+                    y: y
+                }.to_event()),
             sdl2::event::Event::KeyDown { scancode, .. } => if let Some(code) = self.convert_scancode(scancode, shift) {
-                events.push(KeyEvent {
-                    character: code.0,
-                    scancode: code.1,
-                    pressed: true
-                }.to_event());
-            },
+                    /* TODO - figure out what to do with `keycode` (which atm is scancode) and `modifiers` */
+                    events.push(KeyEvent {
+                        character: code.0,
+                        keycode: code.1,
+                        pressed: true,
+                        modifiers: ModKeys::empty(),
+                    }.to_event());
+                },
             sdl2::event::Event::KeyUp { scancode, .. } => if let Some(code) = self.convert_scancode(scancode, shift) {
-                events.push(KeyEvent {
-                    character: code.0,
-                    scancode: code.1,
-                    pressed: false
-                }.to_event());
-            },
+                    /* TODO - figure out what to do with `keycode` and `modifiers` */
+                    events.push(KeyEvent {
+                        character: code.0,
+                        keycode: code.1,
+                        pressed: false,
+                        modifiers: ModKeys::empty(),
+                    }.to_event());
+                },
             sdl2::event::Event::Quit { .. } => events.push(QuitEvent.to_event()),
             _ => (),
         }

--- a/src/input/event.rs
+++ b/src/input/event.rs
@@ -94,137 +94,27 @@ impl DerefMut for Event {
     }
 }
 
-pub const K_A: u8 = 0x1E;
-pub const K_B: u8 = 0x30;
-pub const K_C: u8 = 0x2E;
-pub const K_D: u8 = 0x20;
-pub const K_E: u8 = 0x12;
-pub const K_F: u8 = 0x21;
-pub const K_G: u8 = 0x22;
-pub const K_H: u8 = 0x23;
-pub const K_I: u8 = 0x17;
-pub const K_J: u8 = 0x24;
-pub const K_K: u8 = 0x25;
-pub const K_L: u8 = 0x26;
-pub const K_M: u8 = 0x32;
-pub const K_N: u8 = 0x31;
-pub const K_O: u8 = 0x18;
-pub const K_P: u8 = 0x19;
-pub const K_Q: u8 = 0x10;
-pub const K_R: u8 = 0x13;
-pub const K_S: u8 = 0x1F;
-pub const K_T: u8 = 0x14;
-pub const K_U: u8 = 0x16;
-pub const K_V: u8 = 0x2F;
-pub const K_W: u8 = 0x11;
-pub const K_X: u8 = 0x2D;
-pub const K_Y: u8 = 0x15;
-pub const K_Z: u8 = 0x2C;
-pub const K_0: u8 = 0x0B;
-pub const K_1: u8 = 0x02;
-pub const K_2: u8 = 0x03;
-pub const K_3: u8 = 0x04;
-pub const K_4: u8 = 0x05;
-pub const K_5: u8 = 0x06;
-pub const K_6: u8 = 0x07;
-pub const K_7: u8 = 0x08;
-pub const K_8: u8 = 0x09;
-pub const K_9: u8 = 0x0A;
-
-/// Tick/tilde key
-pub const K_TICK: u8 = 0x29;
-/// Minus/underline key
-pub const K_MINUS: u8 = 0x0C;
-/// Equals/plus key
-pub const K_EQUALS: u8 = 0x0D;
-/// Backslash/pipe key
-pub const K_BACKSLASH: u8 = 0x2B;
-/// Bracket open key
-pub const K_BRACE_OPEN: u8 = 0x1A;
-/// Bracket close key
-pub const K_BRACE_CLOSE: u8 = 0x1B;
-/// Semicolon key
-pub const K_SEMICOLON: u8 = 0x27;
-/// Quote key
-pub const K_QUOTE: u8 = 0x28;
-/// Comma key
-pub const K_COMMA: u8 = 0x33;
-/// Period key
-pub const K_PERIOD: u8 = 0x34;
-/// Slash key
-pub const K_SLASH: u8 = 0x35;
-/// Backspace key
-pub const K_BKSP: u8 = 0x0E;
-/// Space key
-pub const K_SPACE: u8 = 0x39;
-/// Tab key
-pub const K_TAB: u8 = 0x0F;
-/// Capslock
-pub const K_CAPS: u8 = 0x3A;
-/// Left shift
-pub const K_LEFT_SHIFT: u8 = 0x2A;
-/// Right shift
-pub const K_RIGHT_SHIFT: u8 = 0x36;
-/// Control key
-pub const K_CTRL: u8 = 0x1D;
-/// Alt key
-pub const K_ALT: u8 = 0x38;
-/// Enter key
-pub const K_ENTER: u8 = 0x1C;
-/// Escape key
-pub const K_ESC: u8 = 0x01;
-/// F1 key
-pub const K_F1: u8 = 0x3B;
-/// F2 key
-pub const K_F2: u8 = 0x3C;
-/// F3 key
-pub const K_F3: u8 = 0x3D;
-/// F4 key
-pub const K_F4: u8 = 0x3E;
-/// F5 key
-pub const K_F5: u8 = 0x3F;
-/// F6 key
-pub const K_F6: u8 = 0x40;
-/// F7 key
-pub const K_F7: u8 = 0x41;
-/// F8 key
-pub const K_F8: u8 = 0x42;
-/// F9 key
-pub const K_F9: u8 = 0x43;
-/// F10 key
-pub const K_F10: u8 = 0x44;
-/// Home key
-pub const K_HOME: u8 = 0x47;
-/// Up key
-pub const K_UP: u8 = 0x48;
-/// Page up key
-pub const K_PGUP: u8 = 0x49;
-/// Left key
-pub const K_LEFT: u8 = 0x4B;
-/// Right key
-pub const K_RIGHT: u8 = 0x4D;
-/// End key
-pub const K_END: u8 = 0x4F;
-/// Down key
-pub const K_DOWN: u8 = 0x50;
-/// Page down key
-pub const K_PGDN: u8 = 0x51;
-/// Delete key
-pub const K_DEL: u8 = 0x53;
-/// F11 key
-pub const K_F11: u8 = 0x57;
-/// F12 key
-pub const K_F12: u8 = 0x58;
+bitflags! {
+    pub flags ModKeys: u32 {
+        const MOD_LSHIFT    = 1 << 0,
+        const MOD_RSHIFT    = 1 << 1,
+        const MOD_ALT       = 1 << 2,
+        const MOD_ALT_GR    = 1 << 3,
+        const MOD_SUPER     = 1 << 4,
+    }
+}
 
 /// A key event (such as a pressed key)
 #[derive(Copy, Clone, Debug)]
 pub struct KeyEvent {
-    /// The charecter of the key
+    /// The character of the key
     pub character: char,
-    /// The scancode of the key
-    pub scancode: u8,
+    /// The keycode of the key.
+    pub keycode: u8,
     /// Was it pressed?
     pub pressed: bool,
+    /// Modifier keys at the time it was pressed
+    pub modifiers: ModKeys,
 }
 
 impl KeyEvent {
@@ -233,7 +123,7 @@ impl KeyEvent {
         Event {
             code: EVENT_KEY,
             a: self.character as i64,
-            b: self.scancode as i64 | (self.pressed as i64) << 8,
+            b: self.keycode as i64 | (self.pressed as i64) << 8 | (self.modifiers.bits as i64) << 16,
         }
     }
 
@@ -241,8 +131,9 @@ impl KeyEvent {
     pub fn from_event(event: Event) -> KeyEvent {
         KeyEvent {
             character: char::from_u32(event.a as u32).unwrap_or('\0'),
-            scancode: event.b as u8,
+            keycode: event.b as u8,
             pressed: event.b & 1 << 8 == 1 << 8,
+            modifiers: ModKeys::from_bits_truncate((event.b as u32) >> 16),
         }
     }
 }

--- a/src/input/keycode.rs
+++ b/src/input/keycode.rs
@@ -1,0 +1,125 @@
+/// KC for KeyCode
+
+pub const KC_A: u8 = 0x1E;
+pub const KC_B: u8 = 0x30;
+pub const KC_C: u8 = 0x2E;
+pub const KC_D: u8 = 0x20;
+pub const KC_E: u8 = 0x12;
+pub const KC_F: u8 = 0x21;
+pub const KC_G: u8 = 0x22;
+pub const KC_H: u8 = 0x23;
+pub const KC_I: u8 = 0x17;
+pub const KC_J: u8 = 0x24;
+pub const KC_K: u8 = 0x25;
+pub const KC_L: u8 = 0x26;
+pub const KC_M: u8 = 0x32;
+pub const KC_N: u8 = 0x31;
+pub const KC_O: u8 = 0x18;
+pub const KC_P: u8 = 0x19;
+pub const KC_Q: u8 = 0x10;
+pub const KC_R: u8 = 0x13;
+pub const KC_S: u8 = 0x1F;
+pub const KC_T: u8 = 0x14;
+pub const KC_U: u8 = 0x16;
+pub const KC_V: u8 = 0x2F;
+pub const KC_W: u8 = 0x11;
+pub const KC_X: u8 = 0x2D;
+pub const KC_Y: u8 = 0x15;
+pub const KC_Z: u8 = 0x2C;
+pub const KC_0: u8 = 0x0B;
+pub const KC_1: u8 = 0x02;
+pub const KC_2: u8 = 0x03;
+pub const KC_3: u8 = 0x04;
+pub const KC_4: u8 = 0x05;
+pub const KC_5: u8 = 0x06;
+pub const KC_6: u8 = 0x07;
+pub const KC_7: u8 = 0x08;
+pub const KC_8: u8 = 0x09;
+pub const KC_9: u8 = 0x0A;
+
+/// Tick/tilde key
+pub const KC_TICK: u8 = 0x29;
+/// Minus/underline key
+pub const KC_MINUS: u8 = 0x0C;
+/// Equals/plus key
+pub const KC_EQUALS: u8 = 0x0D;
+/// Backslash/pipe key
+pub const KC_BACKSLASH: u8 = 0x2B;
+/// Bracket open key
+pub const KC_BRACE_OPEN: u8 = 0x1A;
+/// Bracket close key
+pub const KC_BRACE_CLOSE: u8 = 0x1B;
+/// Semicolon key
+pub const KC_SEMICOLON: u8 = 0x27;
+/// Quote key
+pub const KC_QUOTE: u8 = 0x28;
+/// Comma key
+pub const KC_COMMA: u8 = 0x33;
+/// Period key
+pub const KC_PERIOD: u8 = 0x34;
+/// Slash key
+pub const KC_SLASH: u8 = 0x35;
+/// Backspace key
+pub const KC_BKSP: u8 = 0x0E;
+/// Space key
+pub const KC_SPACE: u8 = 0x39;
+/// Tab key
+pub const KC_TAB: u8 = 0x0F;
+/// Capslock
+pub const KC_CAPS: u8 = 0x3A;
+/// Left shift
+pub const KC_LEFT_SHIFT: u8 = 0x2A;
+/// Right shift
+pub const KC_RIGHT_SHIFT: u8 = 0x36;
+/// Control key
+pub const KC_CTRL: u8 = 0x1D;
+/// Left alt key
+pub const KC_ALT: u8 = 0x38;
+/// AltGr key
+pub const KC_ALT_GR: u8 = 0x64;
+/// Enter key
+pub const KC_ENTER: u8 = 0x1C;
+/// Escape key
+pub const KC_ESC: u8 = 0x01;
+/// F1 key
+pub const KC_F1: u8 = 0x3B;
+/// F2 key
+pub const KC_F2: u8 = 0x3C;
+/// F3 key
+pub const KC_F3: u8 = 0x3D;
+/// F4 key
+pub const KC_F4: u8 = 0x3E;
+/// F5 key
+pub const KC_F5: u8 = 0x3F;
+/// F6 key
+pub const KC_F6: u8 = 0x40;
+/// F7 key
+pub const KC_F7: u8 = 0x41;
+/// F8 key
+pub const KC_F8: u8 = 0x42;
+/// F9 key
+pub const KC_F9: u8 = 0x43;
+/// F10 key
+pub const KC_F10: u8 = 0x44;
+/// Home key
+pub const KC_HOME: u8 = 0x47;
+/// Up key
+pub const KC_UP: u8 = 0x48;
+/// Page up key
+pub const KC_PGUP: u8 = 0x49;
+/// Left key
+pub const KC_LEFT: u8 = 0x4B;
+/// Right key
+pub const KC_RIGHT: u8 = 0x4D;
+/// End key
+pub const KC_END: u8 = 0x4F;
+/// Down key
+pub const KC_DOWN: u8 = 0x50;
+/// Page down key
+pub const KC_PGDN: u8 = 0x51;
+/// Delete key
+pub const KC_DEL: u8 = 0x53;
+/// F11 key
+pub const KC_F11: u8 = 0x57;
+/// F12 key
+pub const KC_F12: u8 = 0x58;

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -1,0 +1,152 @@
+#![allow(unused)]
+use std::u8;
+use std::str;
+use std::default::Default;
+use std::fs::File;
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
+use syscall::{Result, Error, ENOENT};
+
+use input::{ModKeys, MOD_LSHIFT, MOD_RSHIFT, MOD_ALT_GR};
+
+const NUM_MOD_COMBOS: usize = 4;
+const NUM_SCANCODES: usize = 58;
+#[allow(unused)]
+pub struct Keymap {
+    map: [[char; NUM_MOD_COMBOS]; NUM_SCANCODES],
+}
+
+// Basic parsing as as temporary solution
+#[allow(unused)]
+impl Keymap {
+    /// `path` must be a CSV file with separator '\t'.
+    pub fn from_file(path: &str) -> Result<Keymap> {
+        let mut map = [[0 as char; NUM_MOD_COMBOS]; NUM_SCANCODES];
+
+        let mut string = String::new();
+        match File::open(path) {
+            Ok(mut file) => match file.read_to_string(&mut string) {
+                Ok(_) => {},
+                Err(err) => // Could not read to string
+                    return Err(Error::new(ENOENT))
+            },
+            Err(err) => // Could not open file
+                return Err(Error::new(ENOENT))
+            
+        }
+
+        for (i, line) in string.lines().enumerate() {
+            if i >= NUM_SCANCODES { break; }
+            for (j, element) in line.split('\t').enumerate() {
+                if j >= NUM_MOD_COMBOS { break; }
+                map[i][j] = to_char(&element.as_bytes());
+            }
+        }
+
+        Ok(Keymap {
+            map: map
+        })
+    }
+
+    pub fn get_char(&self, keycode: u8, modifiers: ModKeys) -> char {
+        self.map[keycode as usize][Keymap::mods_to_index(modifiers)]
+    }
+
+    fn mods_to_index(m: ModKeys) -> usize {
+        // (alt_gr << 1) | (shift)
+        (((m.contains(MOD_ALT_GR) as u8) << 1) | (m.intersects(MOD_LSHIFT | MOD_RSHIFT) as u8)) as usize
+    }
+}
+
+/// Parse single character from text.
+#[allow(unused)]
+fn to_char(text: &[u8]) -> char {
+    match text.len() {
+        1 => text[0] as char,
+
+        2 => match text[1] {
+                // Explicit hex string with one digit
+                b'0' ... b'9' | b'A' ... b'F' => {
+                    u8::from_str_radix(str::from_utf8(&text[1..2]).unwrap_or("0"), 16).unwrap_or(0) as char
+                }
+                b'n' => '\n',
+                b't' => '\t',
+                // Quote, single quote or backslash, or some character I haven't yet thought about
+                c => c as char,
+            },
+        3 => {
+            u8::from_str_radix(str::from_utf8(&text[1..3]).unwrap_or("0"), 16).unwrap_or(0) as char
+        }
+        _ => 0 as char,
+    }
+}
+
+
+impl Default for Keymap {
+    /// 'English' layout.
+    fn default() -> Keymap {
+        Keymap {
+            map: [
+                ['\0', '\0', '\0', '\0'],
+                ['\x1B', '\x1B', '\0', '\0'],
+                ['1', '!', '\0', '\0'],
+                ['2', '@', '\0', '\0'],
+                ['3', '#', '\0', '\0'],
+                ['4', '$', '\0', '\0'],
+                ['5', '%', '\0', '\0'],
+                ['6', '^', '\0', '\0'],
+                ['7', '&', '\0', '\0'],
+                ['8', '*', '\0', '\0'],
+                ['9', '(', '\0', '\0'],
+                ['0', ')', '\0', '\0'],
+                ['-', '_', '\0', '\0'],
+                ['=', '+', '\0', '\0'],
+                ['\x7F', '\x7F', '\0', '\0'],
+                ['\t', '\t', '\0', '\0'],
+                ['q', 'Q', '\0', '\0'],
+                ['w', 'W', '\0', '\0'],
+                ['e', 'E', '\0', '\0'],
+                ['r', 'R', '\0', '\0'],
+                ['t', 'T', '\0', '\0'],
+                ['y', 'Y', '\0', '\0'],
+                ['u', 'U', '\0', '\0'],
+                ['i', 'I', '\0', '\0'],
+                ['o', 'O', '\0', '\0'],
+                ['p', 'P', '\0', '\0'],
+                ['[', '{', '\0', '\0'],
+                [']', '}', '\0', '\0'],
+                ['\n', '\n', '\0', '\0'],
+                ['\0', '\0', '\0', '\0'],
+                ['a', 'A', '\0', '\0'],
+                ['s', 'S', '\0', '\0'],
+                ['d', 'D', '\0', '\0'],
+                ['f', 'F', '\0', '\0'],
+                ['g', 'G', '\0', '\0'],
+                ['h', 'H', '\0', '\0'],
+                ['j', 'J', '\0', '\0'],
+                ['k', 'K', '\0', '\0'],
+                ['l', 'L', '\0', '\0'],
+                [';', ':', '\0', '\0'],
+                ['\'', '"', '\0', '\0'],
+                ['`', '~', '\0', '\0'],
+                ['\0', '\0', '\0', '\0'],
+                ['\\', '|', '\0', '\0'],
+                ['z', 'Z', '\0', '\0'],
+                ['x', 'X', '\0', '\0'],
+                ['c', 'C', '\0', '\0'],
+                ['v', 'V', '\0', '\0'],
+                ['b', 'B', '\0', '\0'],
+                ['n', 'N', '\0', '\0'],
+                ['m', 'M', '\0', '\0'],
+                [',', '<', '\0', '\0'],
+                ['.', '>', '\0', '\0'],
+                ['/', '?', '\0', '\0'],
+                ['\0', '\0', '\0', '\0'],
+                ['\0', '\0', '\0', '\0'],
+                ['\0', '\0', '\0', '\0'],
+                [' ', ' ', '\0', '\0']
+            ]
+        }
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,0 +1,7 @@
+pub mod event;
+pub mod keymap;
+pub mod keycode;
+pub mod scancode;
+
+pub use self::event::*;
+pub use self::keymap::*;

--- a/src/input/scancode.rs
+++ b/src/input/scancode.rs
@@ -1,0 +1,123 @@
+/// SC for ScanCode
+
+pub const SC_A: u8 = 0x1E;
+pub const SC_B: u8 = 0x30;
+pub const SC_C: u8 = 0x2E;
+pub const SC_D: u8 = 0x20;
+pub const SC_E: u8 = 0x12;
+pub const SC_F: u8 = 0x21;
+pub const SC_G: u8 = 0x22;
+pub const SC_H: u8 = 0x23;
+pub const SC_I: u8 = 0x17;
+pub const SC_J: u8 = 0x24;
+pub const SC_K: u8 = 0x25;
+pub const SC_L: u8 = 0x26;
+pub const SC_M: u8 = 0x32;
+pub const SC_N: u8 = 0x31;
+pub const SC_O: u8 = 0x18;
+pub const SC_P: u8 = 0x19;
+pub const SC_Q: u8 = 0x10;
+pub const SC_R: u8 = 0x13;
+pub const SC_S: u8 = 0x1F;
+pub const SC_T: u8 = 0x14;
+pub const SC_U: u8 = 0x16;
+pub const SC_V: u8 = 0x2F;
+pub const SC_W: u8 = 0x11;
+pub const SC_X: u8 = 0x2D;
+pub const SC_Y: u8 = 0x15;
+pub const SC_Z: u8 = 0x2C;
+pub const SC_0: u8 = 0x0B;
+pub const SC_1: u8 = 0x02;
+pub const SC_2: u8 = 0x03;
+pub const SC_3: u8 = 0x04;
+pub const SC_4: u8 = 0x05;
+pub const SC_5: u8 = 0x06;
+pub const SC_6: u8 = 0x07;
+pub const SC_7: u8 = 0x08;
+pub const SC_8: u8 = 0x09;
+pub const SC_9: u8 = 0x0A;
+
+/// Tick/tilde key
+pub const SC_TICK: u8 = 0x29;
+/// Minus/underline key
+pub const SC_MINUS: u8 = 0x0C;
+/// Equals/plus key
+pub const SC_EQUALS: u8 = 0x0D;
+/// Backslash/pipe key
+pub const SC_BACKSLASH: u8 = 0x2B;
+/// Bracket open key
+pub const SC_BRACE_OPEN: u8 = 0x1A;
+/// Bracket close key
+pub const SC_BRACE_CLOSE: u8 = 0x1B;
+/// Semicolon key
+pub const SC_SEMICOLON: u8 = 0x27;
+/// Quote key
+pub const SC_QUOTE: u8 = 0x28;
+/// Comma key
+pub const SC_COMMA: u8 = 0x33;
+/// Period key
+pub const SC_PERIOD: u8 = 0x34;
+/// Slash key
+pub const SC_SLASH: u8 = 0x35;
+/// Backspace key
+pub const SC_BKSP: u8 = 0x0E;
+/// Space key
+pub const SC_SPACE: u8 = 0x39;
+/// Tab key
+pub const SC_TAB: u8 = 0x0F;
+/// Capslock
+pub const SC_CAPS: u8 = 0x3A;
+/// Left shift
+pub const SC_LEFT_SHIFT: u8 = 0x2A;
+/// Right shift
+pub const SC_RIGHT_SHIFT: u8 = 0x36;
+/// Control key
+pub const SC_CTRL: u8 = 0x1D;
+/// Left alt key
+pub const SC_ALT: u8 = 0x38;
+/// Enter key
+pub const SC_ENTER: u8 = 0x1C;
+/// Escape key
+pub const SC_ESC: u8 = 0x01;
+/// F1 key
+pub const SC_F1: u8 = 0x3B;
+/// F2 key
+pub const SC_F2: u8 = 0x3C;
+/// F3 key
+pub const SC_F3: u8 = 0x3D;
+/// F4 key
+pub const SC_F4: u8 = 0x3E;
+/// F5 key
+pub const SC_F5: u8 = 0x3F;
+/// F6 key
+pub const SC_F6: u8 = 0x40;
+/// F7 key
+pub const SC_F7: u8 = 0x41;
+/// F8 key
+pub const SC_F8: u8 = 0x42;
+/// F9 key
+pub const SC_F9: u8 = 0x43;
+/// F10 key
+pub const SC_F10: u8 = 0x44;
+/// Home key
+pub const SC_HOME: u8 = 0x47;
+/// Up key
+pub const SC_UP: u8 = 0x48;
+/// Page up key
+pub const SC_PGUP: u8 = 0x49;
+/// Left key
+pub const SC_LEFT: u8 = 0x4B;
+/// Right key
+pub const SC_RIGHT: u8 = 0x4D;
+/// End key
+pub const SC_END: u8 = 0x4F;
+/// Down key
+pub const SC_DOWN: u8 = 0x50;
+/// Page down key
+pub const SC_PGDN: u8 = 0x51;
+/// Delete key
+pub const SC_DEL: u8 = 0x53;
+/// F11 key
+pub const SC_F11: u8 = 0x57;
+/// F12 key
+pub const SC_F12: u8 = 0x58;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,17 +6,21 @@
 #![deny(warnings)]
 
 extern crate core;
+extern crate syscall;
+
+#[macro_use]
+extern crate bitflags;
 
 pub static FONT: &'static [u8] = include_bytes!("../res/unifont.font");
 
 pub use color::Color;
-pub use event::*;
 pub use imp::{get_display_size, EventIter, Window};
+pub use input::*;
 pub use graphicspath::GraphicsPath;
 pub use renderer::Renderer;
 
 pub mod color;
-pub mod event;
+pub mod input;
 pub mod graphicspath;
 pub mod renderer;
 


### PR DESCRIPTION
There are upcoming PRs in `drivers` and `orbtk` to adapt to these changes.

### Separation between keycodes and scancodes.
At the moment, it's roughly a one-to-one mapping between the two. I aimed to just make it work, and not carry out a thorough definition of all keycodes that could be needed. Now the structure is there.
It went from `K_*`, to `keycode::KC_*` for keycodes and `scancode::SC_*` for scancodes.

### Changes to KeyEvent
* KeyEvent takes a keycode rather than a scancode.
* KeyEvent holds a byte with modifier keys. This is not strictly necessary but very convenient.

### keymap module
`struct Keymap` is only used in `drivers/vesad`, and should probably be moved there. However, I also think we should consider moving certain other things (perhaps everything in the new "input" module) such as event structs (seeing as `ps2d` depends on `orbclient` solely to agree upon these). But I saw it as an okay solution to keep these things in `orbclient` for now, since `ps2d` already depends on it.

Keymaps follow a very simple format (_never mind_ the comment in the code mentioning CSV, it's irrelevant and I will remove it). Each line is for a keycode corresponding to that line number. Entries are divided in columns with _hard tabs_. Each entry can be a single character, or a hexadecimal number with a preceding backslash. **This ought to change to a more user-friendly format.**