### PR TITLE
fix renderer bug when displaying a circle filled in with rgba color 

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -25,8 +25,9 @@ fn main() {
     window.arc(100, 100, -25, 1 << 5 | 1 << 7, Color::rgb(255, 255, 0));
     window.circle(100, 100, 25, Color::rgb(0, 0, 0));
     window.circle(100, 101, -25, Color::rgb(0, 255, 0));
+    window.circle(220, 220, -100, Color::rgba(128, 128,128,80));
     window.line(0, 0, 200, 200, Color::rgb(255, 0, 0));
-    window.line(0, 200, 200, 0, Color::rgb(0, 255, 0));
+    window.line(0, 200, 200, 0, Color::rgb(128, 255, 0));
     // vertical and horizontal line test
     window.line(100, 0, 100, 200, Color::rgb(0, 0, 255));
     window.line(0, 100, 200, 100, Color::rgb(255, 255, 0));

--- a/src/imp/sdl2.rs
+++ b/src/imp/sdl2.rs
@@ -171,7 +171,7 @@ impl Window {
 
     // Set position
     pub fn set_pos(&mut self, x: i32, y: i32) {
-        if let Some(mut window) = self.inner.window_mut() {
+        if let Some(window) = self.inner.window_mut() {
             let _ = window.set_position(sdl2::video::WindowPos::Positioned(x),
                                         sdl2::video::WindowPos::Positioned(y));
         }
@@ -180,7 +180,7 @@ impl Window {
 
     // Set size
     pub fn set_size(&mut self, width: u32, height: u32) {
-        if let Some(mut window) = self.inner.window_mut() {
+        if let Some(window) = self.inner.window_mut() {
             let _ = window.set_size(width, height);
         }
         self.sync_path();
@@ -188,7 +188,7 @@ impl Window {
 
     /// Set title
     pub fn set_title(&mut self, title: &str) {
-        if let Some(mut window) = self.inner.window_mut() {
+        if let Some(window) = self.inner.window_mut() {
             let _ = window.set_title(title);
         }
         self.sync_path();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -118,33 +118,61 @@ pub trait Renderer {
     fn circle(&mut self, x0: i32, y0: i32, radius: i32, color: Color) {
         let mut x = radius.abs();
         let mut y = 0;
-        let mut err = 0;
+        let mut err = -radius.abs();
+        
+        match radius {
+            radius if radius > 0 => {
+                err = 0;
+                while x >= y {
+                    self.pixel(x0 - x, y0 + y, color);
+                    self.pixel(x0 + x, y0 + y, color);
+                    self.pixel(x0 - y, y0 + x, color);
+                    self.pixel(x0 + y, y0 + x, color);
+                    self.pixel(x0 - x, y0 - y, color);
+                    self.pixel(x0 + x, y0 - y, color);
+                    self.pixel(x0 - y, y0 - x, color);
+                    self.pixel(x0 + y, y0 - x, color);
+                
+                    y += 1;
+                    err += 1 + 2*y;
+                    if 2*(err-x) + 1 > 0 {
+                        x -= 1;
+                        err += 1 - 2*x;
+                    }
+                }      
+            },
+            
+            radius if radius < 0 => {
+                while x >= y {
+                    let lasty = y;
+                    err +=y;
+                    y +=1;
+                    err += y;
+                    self.line4points(x0,y0,x,lasty,color);
+                    if err >=0 {
+                        if x != lasty{
+                           self.line4points(x0,y0,lasty,x,color);
+                        }
+                        err -= x;
+                        x -= 1;
+                        err -= x;
+                    }
+                }
 
-        while x >= y {
-            if radius < 0 {
-                self.rect(x0 - x, y0 + y, x as u32 * 2 + 1, 1, color);
-                self.rect(x0 - y, y0 + x, y as u32 * 2 + 1, 1, color);
-                self.rect(x0 - x, y0 - y, x as u32 * 2 + 1, 1, color);
-                self.rect(x0 - y, y0 - x, y as u32 * 2 + 1, 1, color);
-            } else if radius == 0 {
-                self.pixel(x0, y0, color);
-            } else {
-                self.pixel(x0 - x, y0 + y, color);
-                self.pixel(x0 + x, y0 + y, color);
-                self.pixel(x0 - y, y0 + x, color);
-                self.pixel(x0 + y, y0 + x, color);
-                self.pixel(x0 - x, y0 - y, color);
-                self.pixel(x0 + x, y0 - y, color);
-                self.pixel(x0 - y, y0 - x, color);
-                self.pixel(x0 + y, y0 - x, color);
-            }
-
-            y += 1;
-            err += 1 + 2*y;
-            if 2*(err-x) + 1 > 0 {
-                x -= 1;
-                err += 1 - 2*x;
-            }
+                },
+                     _ => {
+                            self.pixel(x0, y0, color);
+                            
+                        },
+        }
+    }
+    
+    fn line4points(&mut self, x0: i32, y0: i32, x: i32, y: i32, color: Color){
+        //self.line(x0 - x, y0 + y, (x+x0), y0 + y, color);
+        self.rect(x0 - x, y0 + y, x as u32 * 2 + 1, 1, color);
+        if y != 0 {
+            //self.line(x0 - x, y0 - y, (x+x0), y0-y , color);
+            self.rect(x0 - x, y0 - y, x as u32 * 2 + 1, 1, color);
         }
     }
 


### PR DESCRIPTION
@jackpot51 There is a bug rendering a circle filled with rgba color when alfa is not ff ; there are some horizontal line because those pixel are cycled multiple times .
![circle_bug](https://user-images.githubusercontent.com/29245275/30170149-fcd973d8-93f6-11e7-89e7-8d8b76ed0ce0.png)

I pushed a fix so the circle will render corectly when filled in rgba colors.

![circle_nobug](https://user-images.githubusercontent.com/29245275/30170306-71d9cc46-93f7-11e7-9bae-113d1b932716.png)

Updated example , resolved some complains in sdl2.rs about "variable does not need to be mutable" too.

Hope you like it. 

