### PR TITLE
mplement PartialEq for Color, fix compiler warning: borrow of packed field requires unsafe function or block (error E0133).

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -63,6 +63,12 @@ fn main() {
     // testing for non existent x,y position : does not panic but returns Color(0,0,0,0)
     let _non_existent_pixel = window.getpixel(width as i32 +10,height as i32 +10);
     
+    // testing PartialEq for Color
+    if Color::rgb(11,2,3) == Color::rgba(1,2,3,100) {
+        println!("Testing colors: they are the same!")
+    }else{
+        println!("Testing colors: they are NOT the same!")
+    }
 
     window.sync();
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -53,9 +53,18 @@ impl Color {
     }
 }
 
+/// Compare two colors (Do not take care of alpha)
+impl PartialEq for Color{
+    fn eq(&self, other: &Color) -> bool {
+        self.r() == other.r() &&
+        self.g() == other.g() &&
+        self.b() == other.b()
+    }
+}
+
 #[cfg(not(feature="no_std"))]
 impl fmt::Debug for Color {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{:#010X}", self.data)
+        write!(f, "{:#010X}", {self.data})
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -56,7 +56,7 @@ pub trait Renderer {
 
             let alpha = (new >> 24) & 0xFF;
             if alpha > 0 {
-                let old = &mut data[y as usize * w as usize + x as usize].data;
+                let old = unsafe{ &mut data[y as usize * w as usize + x as usize].data};
                 if alpha >= 255 {
                     *old = new;
                 } else {


### PR DESCRIPTION
@jackpot51 I implemented PartialEq for Color, but last rustc nightly (2018-02-03) complains about "borrow of packed field requires unsafe function or block (error E0133)" . I fixed orbclient sources to compile again under Linux. I hope this is the proper way also for Redox.  