### PR TITLE
Image:  parallel rendering  and window overwriting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = [
 
 [dependencies]
 time = "*"
+rayon = "1.0"
 
 [features]
 default = []

--- a/examples/image_bench.rs
+++ b/examples/image_bench.rs
@@ -20,50 +20,48 @@ fn main() {
     //create image data : a green square
     let data = vec![Color::rgba(100,200,10,20);412500];
     let data2 = vec![Color::rgba(200,100,10,20);412500];
-    let data3 = vec![Color::rgba(10,100,200,20);800];
+    let data3 = vec![Color::rgba(10,100,100,20);412500];
     let data4 = vec![Color::rgba(10,100,200,20);480000];
 
     //draw image benchmarking 
     println!("Benchmarking implementations to draw an image on window:");
     let mut t = time::now();
-    
+
     for _i in 0..TIMES {
-        window.image_legacy(10,10,750,550, &data[..]);
+        window.image_over(50, &data4[..360000]);
     }
     let mut t2 = time::now();
-    let dt = (t2-t)/TIMES;
-    println!("image_legacy {:?}",dt );
+    let dt4 = (t2-t)/TIMES;
+    println!("image_over     {:?}",dt4);
 
     t = time::now();
     
     for _i in 0..TIMES {
-        window.image_fast(40,40,750,550, &data2[..]);
+        window.image_legacy(10,10,750,550, &data[..]);
+    }
+    t2 = time::now();
+    let dt = (t2-t)/TIMES;
+    println!("image_legacy   {:?}",dt );
+
+    t = time::now();
+    
+    for _i in 0..TIMES {
+        window.image_fast(20,20,750,550, &data2[..]);
     }
     t2 = time::now();
     let dt2 = (t2-t)/TIMES;
-    println!("image_fast {:?}",dt2);
-    println!("-------------------------");
-    println!("difference {:?}", dt-dt2);
-    
-    
+    println!("image_fast     {:?}",dt2);
+
     t = time::now();
-    
     for _i in 0..TIMES {
-        window.image(0,0,800,10, &data3[..]);
+        window.image(30,30,750,550, &data3[..]);
     }
     t2 = time::now();
     let dt3 = (t2-t)/TIMES;
-    println!("image wrapper {:?}",dt3);
+    println!("image_parallel {:?}",dt3);
     
-    println!("Overwrite window!");
-    
-    t = time::now();
-    for _i in 0..TIMES {
-        window.image_over(80, &data4[..380000]);
-    }
-    t2 = time::now();
-    let dt4 = (t2-t)/TIMES;
-    println!("window blit {:?}",dt4);
+    //println!("difference {:?}", dt-dt3);
+    println!("-------------------------");
     
     window.sync();
 

--- a/examples/image_bench.rs
+++ b/examples/image_bench.rs
@@ -3,7 +3,7 @@ extern crate time;
 
 use orbclient::{Color, Window, Renderer, EventOption};
 
-const TIMES:i32 = 100;
+const TIMES:i32 = 10;
 
 fn main() {
     //let (width, height) = orbclient::get_display_size().unwrap();
@@ -21,6 +21,7 @@ fn main() {
     let data = vec![Color::rgba(100,200,10,20);412500];
     let data2 = vec![Color::rgba(200,100,10,20);412500];
     let data3 = vec![Color::rgba(10,100,200,20);800];
+    let data4 = vec![Color::rgba(10,100,200,20);480000];
 
     //draw image benchmarking 
     println!("Benchmarking implementations to draw an image on window:");
@@ -36,7 +37,7 @@ fn main() {
     t = time::now();
     
     for _i in 0..TIMES {
-        window.image_fast(140,240,750,550, &data2[..]);
+        window.image_fast(40,40,750,550, &data2[..]);
     }
     t2 = time::now();
     let dt2 = (t2-t)/TIMES;
@@ -48,11 +49,21 @@ fn main() {
     t = time::now();
     
     for _i in 0..TIMES {
-        window.image(0,0,800,1, &data3[..]);
+        window.image(0,0,800,10, &data3[..]);
     }
     t2 = time::now();
     let dt3 = (t2-t)/TIMES;
     println!("image wrapper {:?}",dt3);
+    
+    println!("Overwrite window!");
+    
+    t = time::now();
+    for _i in 0..TIMES {
+        window.image_over(80, &data4[..380000]);
+    }
+    t2 = time::now();
+    let dt4 = (t2-t)/TIMES;
+    println!("window blit {:?}",dt4);
     
     window.sync();
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -59,9 +59,7 @@ fn main() {
 
     window.char(200, 200, '═', Color::rgb(0, 0, 0));
     window.char(208, 200, '═', Color::rgb(0, 0, 0));
-    
 
-    
     // testing for non existent x,y position : does not panic but returns Color(0,0,0,0)
     let _non_existent_pixel = window.getpixel(width as i32 +10,height as i32 +10);
     

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -316,6 +316,16 @@ pub trait Renderer {
         }
     }
 
+    ///Display an image overwriting a portion of window starting at given line : very quick!!
+    fn image_over (&mut self, start: i32, image_data: &[Color]) {
+        let start = start as usize * self.width() as usize;
+        let stop = start + image_data.len();
+        let window_data = self.data_mut();
+        if image_data.len() + start > window_data.len() {return};
+        
+        window_data[start..stop].copy_from_slice(image_data);
+    }
+
     // Speed improved, but image has to be all inside of window boundary
     fn image_fast (&mut self, start_x: i32, start_y: i32, w: u32, h: u32, image_data: &[Color]) {
         let window_w = self.width() as usize;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -300,10 +300,8 @@ pub trait Renderer {
         //check if image is inside window 
         if (w + start_x as u32) > self.width() {
             self.image_legacy(start_x, start_y, w, h, data);
-        }else if w * h < 120000 {
+        } else {
             self.image_fast(start_x, start_y, w, h, data);
-        }else{
-            self.image_parallel(start_x, start_y, w, h, data);
         }
     }
 
@@ -372,6 +370,7 @@ pub trait Renderer {
     }
 
     ///Render an image using parallel threads if possible
+    //Works in Linux but not in Redox !
     fn image_parallel(&mut self, start_x: i32, start_y: i32, w: u32, h: u32, image_data: &[Color]) {
         let start_x = start_x as usize;
         let start_y = start_y as usize;


### PR DESCRIPTION
- Draw an image by splitting it in half and render  the two halves using parallel threads thanks to rayon::join.   
- image() wrapper decide wich rendering function to use based on images size. 
Smaller images infact render slower using parallel implementation because of inerent overhead. 
- Very fast non transparent method to render full window (or stripes of it). 
- Update image benchmark