### PR TITLE
Image opaque

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [
 
 [dependencies]
 time = "*"
-rayon = "1.0"
+rayon = "0.7.1"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [
 
 [dependencies]
 time = "*"
-rayon = "0.5.0"
+rayon = "1.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [
 
 [dependencies]
 time = "*"
-rayon = "0.7.1"
+rayon = "0.5.0"
 
 [features]
 default = []

--- a/examples/image_bench.rs
+++ b/examples/image_bench.rs
@@ -54,7 +54,7 @@ fn main() {
 
     t = time::now();
     for _i in 0..TIMES {
-        window.image(30,30,750,550, &data3[..]);
+        window.image_parallel(30,30,750,550, &data3[..]);
     }
     t2 = time::now();
     let dt3 = (t2-t)/TIMES;

--- a/examples/image_bench.rs
+++ b/examples/image_bench.rs
@@ -59,6 +59,14 @@ fn main() {
     t2 = time::now();
     let dt3 = (t2-t)/TIMES;
     println!("image_parallel {:?}",dt3);
+
+    t = time::now();
+    for _i in 0..TIMES {
+        window.image_opaque(40,40,750,550, &data4[..]);
+    }
+    t2 = time::now();
+    let dt3 = (t2-t)/TIMES;
+    println!("image_opaque   {:?}",dt3);
     
     //println!("difference {:?}", dt-dt3);
     println!("-------------------------");

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -346,9 +346,9 @@ pub trait Renderer {
         //copy image slices to window line by line
         for l in 0..h {
             let start = offset + l * width;
-            let mut stop = offset + l * width + w;
+            let mut stop = start + w;
             let begin = l * w;
-            let mut end = l * w + w;
+            let mut end = begin + w;
             //check boundaries
             if start_x + w > width {
                 stop = (start_y + l +1) * width - 1;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -320,7 +320,7 @@ pub trait Renderer {
 
     ///Display an image overwriting a portion of window starting at given line : very quick!!
     fn image_over (&mut self, start: i32, image_data: &[Color]) {
-        
+
         let start = start as usize * self.width() as usize;
         let window_data = self.data_mut();
         let stop = cmp::min(start + image_data.len(), window_data.len());
@@ -329,14 +329,34 @@ pub trait Renderer {
         window_data[start..stop].copy_from_slice(&image_data[..end]);
     }
 
-    fn image_line (&mut self, start_x: i32, start_y: i32, width: u32, image_data: &[Color]) {
-        
-        let start = start_y as usize * self.width() as usize + start_x as usize;
+    ///Display an image using non transparent method 
+    fn image_opaque (&mut self, start_x: i32, start_y: i32, w: u32, h: u32, image_data: &[Color]) {
+        let w = w as usize;
+        let mut h = h as usize;
+        let width = self.width() as usize;
+        let height = self.height() as usize;
+        let start_x = start_x as usize;
+        let start_y =start_y as usize;
+        //check boundaries 
+        if h + start_y > height {
+            h = height - start_y;
+        }
         let window_data = self.data_mut();
-        let stop = start + width as usize;
-        let end = width as usize;
-        
-        window_data[start..stop].copy_from_slice(&image_data[..end]);
+        let offset = start_y * width + start_x;
+        //copy image slices to window line by line
+        for l in 0..h {
+            let start = offset + l * width;
+            let mut stop = offset + l * width + w;
+            let begin = l * w;
+            let mut end = l * w + w;
+            //check boundaries
+            if start_x + w > width {
+                stop = (start_y + l +1) * width - 1;
+                end = begin + stop - start;
+            }
+            window_data[start..stop]
+            .copy_from_slice(&image_data[begin..end]);
+        } 
     }
 
     // Speed improved, but image has to be all inside of window boundary

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -329,6 +329,16 @@ pub trait Renderer {
         window_data[start..stop].copy_from_slice(&image_data[..end]);
     }
 
+    fn image_line (&mut self, start_x: i32, start_y: i32, width: u32, image_data: &[Color]) {
+        
+        let start = start_y as usize * self.width() as usize + start_x as usize;
+        let window_data = self.data_mut();
+        let stop = start + width as usize;
+        let end = width as usize;
+        
+        window_data[start..stop].copy_from_slice(&image_data[..end]);
+    }
+
     // Speed improved, but image has to be all inside of window boundary
     fn image_fast (&mut self, start_x: i32, start_y: i32, w: u32, h: u32, image_data: &[Color]) {
         let window_w = self.width() as usize;


### PR DESCRIPTION
Another fast non-transparent method to draw an image. The image will be rendered correctly even if out of window boundary. 