### PR TITLE
Faster pixel() and even faster image_fast()

### DIFF
--- a/examples/image_bench.rs
+++ b/examples/image_bench.rs
@@ -41,7 +41,7 @@ fn main() {
     }
     t2 = time::now();
     let dt = (t2-t)/TIMES;
-    println!("image_legacy   {:?}",dt );
+    println!("image_legacy (pixel_fast)    {:?}",dt );
 
     t = time::now();
     

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -14,6 +14,7 @@ fn main() {
                          .unwrap();
 
     let (win_w, win_h) = (width/2, height/2);
+
     // top left -> bottom rigth
     window.linear_gradient(0, 0, win_w/3, win_h, 0, 0,  (win_w/3) as i32, (win_h/2) as i32, Color::rgb(128,128,128), Color::rgb(255,255,255));
     // horizontal gradient
@@ -79,7 +80,7 @@ fn main() {
     window.mode().set(Mode::Overwrite); // set window drawing mode to Overwrite from now on 
     window.rect(300, 220, 80, 80, Color::rgb(100,100,100));
     
-    //Possibly draw a hole in the window replacing alpha channel ?? (Only in Orbital, not in SDL2)
+    //Draw a hole in the window replacing alpha channel (Only in Orbital, not in SDL2)
     window.rect(300, 100, 80, 80, Color::rgba(10,10,10,1));
 
     //Draw a transparent rectangle over window content

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ pub enum WindowFlag {
 
 #[derive(Clone, Copy, Debug)]
 pub enum Mode {
-    Blend,      //Composite
-    Overwrite   //Replace 
+    Blend,      //Composite  
+    Overwrite   //Replace
 }
 
 #[cfg(all(not(feature="no_std"), target_os = "redox"))]

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -407,48 +407,6 @@ pub trait Renderer {
     }
 
     // Speed improved, but image has to be all inside of window boundary
-/*
-    #[inline(always)]
-    fn image_fast (&mut self, start_x: i32, start_y: i32, w: u32, h: u32, image_data: &[Color]) {
-        let window_w = self.width() as usize;
-        let window_len = self.data().len();
-        let data = self.data_mut();
-        let w = w as usize;
-        let start_x = start_x as usize;
-        let start_y = start_y as usize;
-
-        for i in 0..(w * h as usize) {
-            let y0 = i / w;
-            let y = y0 + start_y;
-            let x = start_x + i - (y0 * w);
-            let window_index = y * window_w + x;
-            if window_index < window_len && i < image_data.len(){
-                let new = image_data[i].data;
-                let alpha = (new >> 24) & 0xFF;
-                if alpha > 0 {
-                    let old = unsafe{ &mut data[window_index].data};
-                    if alpha >= 255 {
-                        *old = new;
-                    } else {
-                        let n_r = (((new >> 16) & 0xFF) * alpha) >> 8;
-                        let n_g = (((new >> 8) & 0xFF) * alpha) >> 8;
-                        let n_b = ((new & 0xFF) * alpha) >> 8;
-
-                        let n_alpha = 255 - alpha;
-                        let o_a = (((*old >> 24) & 0xFF) * n_alpha) >> 8;
-                        let o_r = (((*old >> 16) & 0xFF) * n_alpha) >> 8;
-                        let o_g = (((*old >> 8) & 0xFF) * n_alpha) >> 8;
-                        let o_b = ((*old & 0xFF) * n_alpha) >> 8;
-
-                        *old = ((o_a << 24) | (o_r << 16) | (o_g << 8) | o_b) + ((alpha << 24) | (n_r << 16) | (n_g << 8) | n_b);
-                    }
-                }
-            }
-            
-        }
-    }
-*/
-
     #[inline(always)]
     fn image_fast(&mut self, start_x: i32, start_y: i32, w: u32, h: u32, image_data: &[Color]) {
         let window_w = self.width() as usize;


### PR DESCRIPTION
Using multiplexing technique calculate pixel alpha blending value for red/blue and alpha/green channels in one pass. 
Credits to https://stackoverflow.com/questions/1102692/how-to-alpha-blend-rgba-unsigned-byte-color-fast