### PR TITLE
Fix issue with edge-triggered orbital

### DIFF
--- a/src/sys/orbital.rs
+++ b/src/sys/orbital.rs
@@ -249,6 +249,10 @@ impl Window {
                             self.set_size(w, h);
                         }
                     }
+                    if !self.async {
+                        // Synchronous windows are blocking, can't attempt another read
+                        break 'blocking;
+                    }
                 },
                 Err(_) => break 'blocking,
             }

--- a/src/sys/orbital.rs
+++ b/src/sys/orbital.rs
@@ -227,7 +227,7 @@ impl Window {
             match self.file.read(bytes) {
                 Ok(0) => if !self.async
                         && iter.extra.is_none()
-                        && iter.events.len() == 0 {
+                        && iter.count == 0 {
                     thread::yield_now();
                 } else {
                     break 'blocking;


### PR DESCRIPTION
**Problem:**
Orbclient's window.read is currently something like "read 16 events thanks" instead of "read all events".
This used to be fine because it was level-triggered, a.k.a. the read event is sent over and over.
Now with the edge-triggered model it fails when there are more than 16 events.

**Solution:**
Read until EOF. This does require a vector, but only if it's more than 16 events.

~~Breaking:
Windows marked as async will break because reads are blocking there.
I have a quick patch for orbterm and launcher that removes the async flag.
What is this flag even? Why is it needed?~~